### PR TITLE
Fix build configuration and cleanup rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,10 +126,11 @@ INC_FOLDERS += \
 	$(SDK_ROOT)/components/libraries/pwr_mgmt \
 	$(SDK_ROOT)/components/libraries/delay \
 	$(SDK_ROOT)/components/libraries/log \
-	$(SDK_ROOT)/components/libraries/log/src \
-	$(SDK_ROOT)/components/libraries/strerror \
-	$(SDK_ROOT)/components/libraries/experimental_section_vars \
-	$(SDK_ROOT)/modules/nrfx \
+        $(SDK_ROOT)/components/libraries/log/src \
+        $(SDK_ROOT)/components/libraries/strerror \
+        $(SDK_ROOT)/components/libraries/mutex \
+        $(SDK_ROOT)/components/libraries/experimental_section_vars \
+        $(SDK_ROOT)/modules/nrfx \
 	$(SDK_ROOT)/modules/nrfx/hal \
 	$(SDK_ROOT)/integration/nrfx \
 	$(SDK_ROOT)/integration/nrfx/legacy \
@@ -194,5 +195,5 @@ $(BUILD_DIR)/$(PROJECT_NAME).out: $(OBJECTS)
 
 
 clean:
-	@if exist $(BUILD_DIR) $(RM) $(BUILD_DIR)
+	$(RM) -rf $(BUILD_DIR)
 

--- a/drivers/notification_service.h
+++ b/drivers/notification_service.h
@@ -248,7 +248,7 @@ uint32_t notification_service_init(notification_service_init_t * p_init)
 
 /**@brief Simple init function without parameters
  */
-void notification_service_init(void)
+static inline void notification_service_init_simple(void)
 {
     notification_service_init_t init = {0};
     uint32_t err_code = notification_service_init(&init);

--- a/main/main.c
+++ b/main/main.c
@@ -433,7 +433,7 @@ int main(void)
     st7789_init();
     step_counter_init();
     time_manager_init();
-    notification_service_init();
+    notification_service_init_simple();
 
     // Initialize LVGL and create UI
     lvgl_init();


### PR DESCRIPTION
## Summary
- add missing mutex path in Makefile include list
- rename simple notification service init helper
- call new helper from `main.c`
- fix `make clean` to work on POSIX

## Testing
- `make clean`
- `make` *(fails: 'BLE_ADV_BLE_OBSERVER_PRIO' undeclared)*

------
https://chatgpt.com/codex/tasks/task_e_684943d2d6ac8332936bf04c202824ac